### PR TITLE
Remove obsoleted arguments for streamlink

### DIFF
--- a/save_livestream.py
+++ b/save_livestream.py
@@ -60,7 +60,7 @@ def download(args, extra=None, quality="best"):
     current_date_time = strftime("%Y-%m-%d %H-%M-%S", gmtime())
     filename = r"{time:%Y%m%d %H-%M-%S} [" + args.author_name + r"] {title} [" + f"{quality}" + r"][{id}].ts"
     cmd = [
-        "streamlink", "--twitch-disable-hosting", "--twitch-disable-ads",
+        "streamlink", "--twitch-disable-hosting",
         "--hls-live-restart", "--stream-segment-timeout", "30",
         "--stream-segment-attempts", "10", "-o", filename
     ]

--- a/save_livestream.py
+++ b/save_livestream.py
@@ -60,7 +60,7 @@ def download(args, extra=None, quality="best"):
     current_date_time = strftime("%Y-%m-%d %H-%M-%S", gmtime())
     filename = r"{time:%Y%m%d %H-%M-%S} [" + args.author_name + r"] {title} [" + f"{quality}" + r"][{id}].ts"
     cmd = [
-        "streamlink", "--twitch-disable-hosting",
+        "streamlink",
         "--hls-live-restart", "--stream-segment-timeout", "30",
         "--stream-segment-attempts", "10", "-o", filename
     ]


### PR DESCRIPTION
We get a warning now saying these arguments are deprecated. 
* My understanding is that streamlink filters out ads by default now: https://streamlink.github.io/changelog.html#streamlink-7-5-0-2025-07-08
* hosting of streams from other channels has been deprecated for a while too: https://streamlink.github.io/changelog.html#streamlink-5-0-0-2022-09-16 